### PR TITLE
fix: dictionary storage async

### DIFF
--- a/apps/simple-admin-core/src/store/dictionary.ts
+++ b/apps/simple-admin-core/src/store/dictionary.ts
@@ -59,9 +59,7 @@ export const useDictionaryStore = defineStore('dictionary', {
       }
     },
     async fetchDictionaryData(name: string) {
-      const mapData: Map<string, DictionaryData> = new Map(
-        JSON.parse(this.data),
-      );
+
       const result = await GetDictionaryDetailByDictionaryName({ name });
       if (result.code === 0) {
         const dataConv = ref<DefaultOptionType[]>([]);
@@ -79,6 +77,9 @@ export const useDictionaryStore = defineStore('dictionary', {
         }
 
         const dictData: DictionaryData = { data: dataConv.value };
+        const mapData: Map<string, DictionaryData> = new Map(
+          JSON.parse(this.data),
+        );
         mapData.set(name, dictData);
         this.data = JSON.stringify([...mapData.entries()]);
         return dictData;


### PR DESCRIPTION
## Description

当我使用Promise.all 等方式 同时获取多个字典的时候，该方法同时运行时，这里的 mapData 是在接口请求之前，每次运行都存储了最开始版本的pinia的字典，最终会导致本次批量获取时，只有最后一个完成获取的字典存储到pinia，同时获取的其他字典会被忽略，从而缓存失败。
<img width="1755" height="911" alt="image" src="https://github.com/user-attachments/assets/588c26bd-9333-4d81-98c7-a7be90e8841c" />


## Type of change

- [Bug fix] fetchDictionaryData cache fix

以下是使用案例

``` typescript
export function useDictionary(names: string[], config?: { valueType?: 'string' | 'number' }) {
  const valueType = config?.valueType || 'number';
  const option = Array(names.length)
    .fill(1)
    .map(() => ref<IOptionType[]>([]));

  const sotre = useDictionaryStore();
  onMounted(() => {
    init();
  });
  const init = async () => {
    const res = await Promise.all(names.map((item) => sotre.getDictionary(item)));
    res.map((item, index) => {
      if (valueType === 'string') {
        option[index].value = item.data || [];
      } else {
        option[index].value = (item.data || []).map((e) => ({ ...e, value: Number(e.value) }));
      }
    });
  };
  return option;
}
```